### PR TITLE
Implement simpler data fetch from OCLC Classify service

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Accepts a Metadata record generated either by harvesting records from one of the
 ## Output
 A **Work** record containing the following fields
 - Title [String]
-- SubTitle [String]
-- AltTitles [Array]
+- Subtitle [String]
+- Alt Title [Array]
 - Source [String]
 - Language [String]
 - License [URI]
@@ -46,4 +46,3 @@ A **Work** record containing the following fields
 
 - Add further comments/tests to increase coverage
 - Chaos test with various strange/incomplete/erroneous input metadata blocks
-- Refactor matching code in several places where it could be cleaner/better

--- a/config.yaml
+++ b/config.yaml
@@ -12,8 +12,8 @@ aws_access_key_id:
 aws_secret_access_key:
 
 # dist_directory: dist
-timeout: 240
-memory_size: 256
+timeout: 15
+memory_size: 128
 
 
 # If `tags` is uncommented then tags will be set at creation or update

--- a/helpers/errorHelpers.py
+++ b/helpers/errorHelpers.py
@@ -19,6 +19,9 @@ class OCLCError(Exception):
     def __init__(self, message):
         self.message = message
 
+class DataError(Exception):
+    def __init__(self, message):
+        self.message = message
 
 class KinesisError(Exception):
     def __init__(self, message):

--- a/lib/dataModel.py
+++ b/lib/dataModel.py
@@ -2,6 +2,8 @@ from Levenshtein import distance, jaro_winkler
 from collections import defaultdict
 
 class DataObject(object):
+    """Abstract data model object that specific classes inherit from. Sets
+    basic functions that allow writing/retrieving attributes."""
     def __init__(self):
         pass
 
@@ -12,11 +14,15 @@ class DataObject(object):
         return self.__dict__[key]
 
     def getDictValue(self):
+        """Convert current object into a dict. Used for generating JSON objects
+        and in other instances where a standard type is necessary."""
         return vars(self)
 
     @classmethod
     def createFromDict(cls, **kwargs):
-
+        """Take a standard dict object and convert to an instance of the
+        provided class. Allows for creation of new instances with arbitrary
+        fields set"""
         record = cls()
         for field, value in kwargs.items():
             record[field] = value

--- a/lib/dataModel.py
+++ b/lib/dataModel.py
@@ -25,27 +25,28 @@ class DataObject(object):
 
 
 class WorkRecord(DataObject):
-    def __init__(self, source=None):
+    def __init__(self):
         super()
-        self.source = source
         self.identifiers = []
         self.instances = []
         self.subjects = []
         self.agents = []
         self.links = []
         self.measurements = []
+        self.uuid = None
         self.license = None
         self.language = None
         self.title = None
-        self.subtitle = None
-        self.altTitle = None
-        self.rightsStatement = None
+        self.sub_title = None
+        self.alt_titles = None
+        self.sort_title = None
+        self.rights_statement = None
         self.issued = None
         self.published = None
         self.medium = None
         self.series = None
         self.seriesPosition = None
-        self.primaryIdentifier = None
+        self.primary_identifier = None
 
     def addIdentifier(self, **identifierDict):
         self.identifiers.append(Identifier.createFromDict(**identifierDict))
@@ -68,15 +69,15 @@ class InstanceRecord(DataObject):
         super()
         self.title = title
         self.language = language
-        self.subtitle = None
-        self.altTitle = None
-        self.pubPlace = None
-        self.pubDate = None
+        self.sub_title = None
+        self.alt_title = None
+        self.pub_place = None
+        self.pub_date = None
         self.edition = None
-        self.editionStatement = None
-        self.tableOfContents = None
-        self.copyrightDate = None
-        self.agents = None
+        self.edition_statement = None
+        self.table_of_contents = None
+        self.copyright_date = None
+        self.agents = []
         self.identifiers = []
         self.formats = []
         self.measurements = []
@@ -85,11 +86,11 @@ class InstanceRecord(DataObject):
 class Format(DataObject):
     def __init__(self, contentType=None, link=None, modified=None):
         super()
-        self.contentType = contentType
+        self.content_type = contentType
         self.modified = modified
         self.drm = None
         self.measurements = []
-        self.rightsURI = None
+        self.rights_uri = None
         self.link = None
 
         if (isinstance(link, Link)):
@@ -106,13 +107,13 @@ class Agent(DataObject):
     def __init__(self, name=None, role=None, aliases=None, birth=None, death=None, link=None):
         super()
         self.name = name
-        self.sortName = None
+        self.sort_name = None
         self.lcnaf = None
         self.viaf = None
         self.biography = None
         self.aliases = aliases
-        self.birthDate = birth
-        self.deathDate = death
+        self.birth_date = birth
+        self.death_date = death
         self.link = link
 
         if isinstance(role, (str, int)):
@@ -168,20 +169,23 @@ class Link(DataObject):
     def __init__(self, url=None, mediaType=None, relType=None):
         super()
         self.url = url
-        self.mediaType = mediaType
+        self.media_type = mediaType
         self.content = None
-        self.relType = None
+        self.rel_type = None
         self.thumbnail = None
 
 
 class Subject(DataObject):
     def __init__(self, subjectType=None, value=None, weight=None):
         super()
-        self.type = subjectType
-        self.identifier = None
-        self.value = value
+        self.authority = subjectType
+        self.subject = value
+        self.uri = None
         self.weight = weight
         self.measurements = []
+
+    def addMeasurement(self, **measurementDict):
+        self.measurements.append(Measurement.createFromDict(**measurementDict))
 
 
 class Measurement(DataObject):
@@ -190,7 +194,7 @@ class Measurement(DataObject):
         self.quantity = quantity
         self.value = value
         self.weight = weight
-        self.takenAt = takenAt
+        self.taken_at = takenAt
 
     @staticmethod
     def getValueForMeasurement(measurementList, quantity):

--- a/lib/enhancer.py
+++ b/lib/enhancer.py
@@ -10,6 +10,9 @@ from lib.kinesisWrite import KinesisOutput
 logger = createLog('enhancer')
 
 def enhanceRecord(record):
+    """Takes a single input record and retrieves data from the OCLC Classify
+    service. Manages the overall workflow of the function."""
+
     try:
         sourceData = record['data']
     except KeyError:
@@ -30,8 +33,8 @@ def enhanceRecord(record):
         return False
 
     logger.info('Starting to enhance work record {}'.format(workUUID))
-    try:
 
+    try:
         # Step 1: Generate a set of XML records retrieved from Classify
         # This step also adds the oclc identifiers to the sourceData record
         classifyData = classifyRecord(searchType, searchFields, workUUID)
@@ -46,6 +49,7 @@ def enhanceRecord(record):
         # Step 2: Parse the data recieved from Classify into the SFR data model
         parsedData = readFromClassify(classifyData)
 
+        # This sets the primary identifier for processing by the db manager
         parsedData.primary_identifier = Identifier('uuid', workUUID, 1)
 
         # Step 3: Output this block to kinesis
@@ -54,4 +58,5 @@ def enhanceRecord(record):
     except OCLCError as err:
         logger.error('OCLC Query failed with message: {}'.format(err.message))
         return False
+
     return True

--- a/lib/enhancer.py
+++ b/lib/enhancer.py
@@ -53,7 +53,13 @@ def enhanceRecord(record):
         parsedData.primary_identifier = Identifier('uuid', workUUID, 1)
 
         # Step 3: Output this block to kinesis
-        KinesisOutput.putRecord(parsedData, os.environ['OUTPUT_KINESIS'])
+        outputObject = {
+            'status': 200,
+            'type': 'work',
+            'method': 'update',
+            'data': parsedData
+        }
+        KinesisOutput.putRecord(outputObject, os.environ['OUTPUT_KINESIS'])
 
     except OCLCError as err:
         logger.error('OCLC Query failed with message: {}'.format(err.message))

--- a/lib/kinesisWrite.py
+++ b/lib/kinesisWrite.py
@@ -16,12 +16,13 @@ class KinesisOutput():
         pass
 
     @classmethod
-    def putRecord(cls, record):
+    def putRecord(cls, record, stream):
 
         logger.info("Writing results to Kinesis")
         outputObject = {
             'status': 200,
-            'stage': os.environ['OUTPUT_STAGE'],
+            'type': 'work',
+            'method': 'update',
             'data': record
         }
         # The default lambda function here converts all objects into dicts
@@ -32,7 +33,7 @@ class KinesisOutput():
         )
         try:
             kinesisResp = cls.KINESIS_CLIENT.put_record(
-                StreamName=os.environ['OUTPUT_KINESIS'],
+                StreamName=stream,
                 Data=kinesisStream,
                 PartitionKey=os.environ['OUTPUT_SHARD']
             )

--- a/lib/kinesisWrite.py
+++ b/lib/kinesisWrite.py
@@ -10,6 +10,7 @@ from helpers.clientHelpers import createAWSClient
 logger = createLog('kinesis_write')
 
 class KinesisOutput():
+    """Class for managing connections and operations with AWS Kinesis"""
     KINESIS_CLIENT = createAWSClient('kinesis')
 
     def __init__(self):
@@ -17,7 +18,7 @@ class KinesisOutput():
 
     @classmethod
     def putRecord(cls, record, stream):
-
+        """Put an event into the specific Kinesis stream"""
         logger.info("Writing results to Kinesis")
         outputObject = {
             'status': 200,

--- a/lib/kinesisWrite.py
+++ b/lib/kinesisWrite.py
@@ -17,15 +17,10 @@ class KinesisOutput():
         pass
 
     @classmethod
-    def putRecord(cls, record, stream):
+    def putRecord(cls, outputObject, stream):
         """Put an event into the specific Kinesis stream"""
         logger.info("Writing results to Kinesis")
-        outputObject = {
-            'status': 200,
-            'type': 'work',
-            'method': 'update',
-            'data': record
-        }
+
         # The default lambda function here converts all objects into dicts
         kinesisStream = json.dumps(
             outputObject,

--- a/lib/parsers/parseOCLC.py
+++ b/lib/parsers/parseOCLC.py
@@ -21,12 +21,11 @@ MARC_FIELDS = {
 }
 
 
-def readFromClassify(xmlData):
-    # Extract relevant data from returned works
+def readFromClassify(workXML):
+    """Parse Classify XML document into a object that complies with the
+    SFR data model. Accepts a single XML document and returns a WorkRecord."""
     logger.debug('Parsing Returned Work')
-    return parseWork(xmlData)
 
-def parseWork(workXML):
     namespaces = {
         None: 'http://classify.oclc.org'
     }
@@ -42,6 +41,7 @@ def parseWork(workXML):
             1,
             MEASUREMENT_TIME
         ))
+    
     oclcNo = Identifier('oclc', work.text, 1)
     owiNo = Identifier('owi', work.get('owi'), 1)
 
@@ -70,7 +70,7 @@ def parseWork(workXML):
 
 
 def parseHeading(heading):
-
+    """Parse a subject heading into a data model object"""
     headingDict = {
         'subject': heading.text,
         'uri': heading.get('ident'),
@@ -88,7 +88,7 @@ def parseHeading(heading):
     return subject
 
 def parseEdition(edition):
-
+    """Parse an edition into a Instance record"""
     oclcNo = Identifier(
         'oclc',
         edition.get('oclc'),
@@ -133,7 +133,7 @@ def parseEdition(edition):
     return InstanceRecord.createFromDict(**editionDict)
 
 def parseClassification(classification):
-
+    """Parse a classification into an identifier for the work record."""
     tag = classification.get('tag')
     subjectType = MARC_FIELDS[tag]
 
@@ -146,7 +146,7 @@ def parseClassification(classification):
     return Identifier.createFromDict(**classDict)
 
 def parseAuthor(author):
-
+    """Parse a supplied author into an agent record."""
     authorDict = {
         'name': author.text,
         'viaf': author.get('viaf'),

--- a/lib/readers/oclcClassify.py
+++ b/lib/readers/oclcClassify.py
@@ -40,6 +40,7 @@ def classifyRecord(searchType, searchFields, workUUID):
 
     # Parse response, and if it is a Multi-Work response, parse further
     logger.debug('Parsing Classify Response')
+    
     return parseClassify(rawData, workUUID)
 
 
@@ -68,7 +69,7 @@ def parseClassify(rawXML, workUUID):
 
     if responseCode == 102:
         logger.info('Did not find any information for this query')
-        return None
+        raise OCLCError('No work records found in OCLC Classify Service')
     elif responseCode == 2:
         logger.debug('Got Single Work, parsing work and edition data')
         return parseXML
@@ -90,7 +91,7 @@ def parseClassify(rawXML, workUUID):
 
             storedWorks.extend(workData)
 
-        return None
+        raise OCLCError('Received Multi-Work response from Classify, returned records to input stream')
     else:
         raise OCLCError('Recieved unexpected response {} from Classify'.format(responseCode))
 

--- a/lib/readers/oclcClassify.py
+++ b/lib/readers/oclcClassify.py
@@ -40,7 +40,7 @@ def classifyRecord(searchType, searchFields, workUUID):
 
     # Parse response, and if it is a Multi-Work response, parse further
     logger.debug('Parsing Classify Response')
-    
+
     return parseClassify(rawData, workUUID)
 
 
@@ -95,7 +95,6 @@ def parseClassify(rawXML, workUUID):
     else:
         raise OCLCError('Recieved unexpected response {} from Classify'.format(responseCode))
 
-        return None
 
 def queryClassify(queryURL):
     """Execute a request against the OCLC Classify service"""

--- a/service.py
+++ b/service.py
@@ -52,14 +52,5 @@ def parseRecord(encodedRec):
         logger.debug(b64Err)
         return False
 
-    status = record['status']
-    stage = record['stage']
-    if status != 200:
-        logger.warning('Bad Record Found! Alert the Authorities')
-        return False
-    elif stage != 'oclc':
-        logger.info('This record is not for this stage, return for further processing')
-        return False
-
     result = enhanceRecord(record)
     return result

--- a/service.py
+++ b/service.py
@@ -12,7 +12,8 @@ logger = createLog('handler')
 
 
 def handler(event, context):
-
+    """Method invoked by Lambda event. Verifies that records were received and,
+    if so, passes them to be parsed"""
     logger.debug('Starting Lambda Execution')
 
     records = event.get('Records')
@@ -24,9 +25,6 @@ def handler(event, context):
         logger.error('Records block contains no records')
         raise NoRecordsReceived('Records block empty', event)
 
-    # Method to be invoked goes here
-    # TODO Implement oauth checking
-
     results = parseRecords(records)
 
     logger.info('Successfully invoked lambda')
@@ -36,11 +34,15 @@ def handler(event, context):
     return results
 
 def parseRecords(records):
+    """Simple method to parse list of records and process each entry."""
     logger.debug("Parsing Messages")
     results = list(map(parseRecord, records))
     return results
 
 def parseRecord(encodedRec):
+    """Parse an individual record. Verifies that an object was able to be
+    decoded from the input base64 encoded string and if so, hands this to the
+    enhancer method"""
     try:
         record = json.loads(base64.b64decode(encodedRec['kinesis']['data']))
     except json.decoder.JSONDecodeError as jsonErr:

--- a/tests/test_dataModel.py
+++ b/tests/test_dataModel.py
@@ -32,9 +32,9 @@ class DataModel(unittest.TestCase):
         self.assertEqual(model.getDictValue(), {'test': 'tester'})
 
     def test_work_create(self):
-        work = WorkRecord('tester')
+        work = WorkRecord()
         self.assertIsInstance(work, WorkRecord)
-        self.assertEqual(work.source, 'tester')
+        self.assertIsInstance(work, WorkRecord)
 
     def test_work_addIdentifier(self):
         work = WorkRecord()
@@ -69,7 +69,7 @@ class DataModel(unittest.TestCase):
     def test_format_create(self):
         testFormat = Format('ebook', 'http://test.test', 'now')
         self.assertIsInstance(testFormat, Format)
-        self.assertEqual(testFormat.contentType, 'ebook')
+        self.assertEqual(testFormat.content_type, 'ebook')
 
     def test_format_create_with_link(self):
         testFormat = Format('ebook', Link('testing'), 'now')

--- a/tests/test_enhancer.py
+++ b/tests/test_enhancer.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch, mock_open, call
 
 from lib.enhancer import enhanceRecord
-from helpers.errorHelpers import OCLCError
+from helpers.errorHelpers import OCLCError, DataError
 from lib.dataModel import WorkRecord
 
 class TestEnhancer(unittest.TestCase):
@@ -32,9 +32,11 @@ class TestEnhancer(unittest.TestCase):
             'source': 'test',
             'recordID': 1
         }
-
-        res = enhanceRecord(testRec)
-        self.assertFalse(res)
+        try:
+            res = enhanceRecord(testRec)
+        except DataError:
+            pass
+        self.assertRaises(OCLCError)
 
     @patch('lib.enhancer.classifyRecord', return_value=(True, True), side_effect=OCLCError('testing'))
     def test_enhancer_err(self, mock_classify):
@@ -43,7 +45,8 @@ class TestEnhancer(unittest.TestCase):
             'recordID': 1,
             'data': 'some data'
         }
-
-        res = enhanceRecord(testRec)
-        self.assertFalse(res)
+        try:
+            res = enhanceRecord(testRec)
+        except DataError:
+            pass
         self.assertRaises(OCLCError)

--- a/tests/test_enhancer.py
+++ b/tests/test_enhancer.py
@@ -1,24 +1,27 @@
 import unittest
 from unittest.mock import patch, mock_open, call
 
-import os
-os.environ['OUTPUT_REGION'] = 'us-test-1'
-
-from lib.enhancer import enhanceRecord, mergeData
+from lib.enhancer import enhanceRecord
 from helpers.errorHelpers import OCLCError
 from lib.dataModel import WorkRecord
 
 class TestEnhancer(unittest.TestCase):
 
+    @patch.dict('os.environ', {'OUTPUT_KINESIS': 'tester', 'OUTPUT_REGION': 'us-test-1'})
     @patch('lib.enhancer.classifyRecord', return_value=(True, True))
     @patch('lib.enhancer.readFromClassify')
-    @patch('lib.enhancer.mergeData')
     @patch('lib.enhancer.KinesisOutput.putRecord')
-    def test_basic_enhancer(self, mock_classify, mock_read, mock_merge, mock_put):
+    def test_basic_enhancer(self, mock_classify, mock_read, mock_put):
         testRec = {
             'source': 'test',
             'recordID': 1,
-            'data': 'some data'
+            'data': {
+                'uuid': '11111111-1111-1111-1111-111111111111',
+                'type': 'test',
+                'fields': {
+                    'test': 'test'
+                }
+            }
         }
 
         res = enhanceRecord(testRec)
@@ -44,27 +47,3 @@ class TestEnhancer(unittest.TestCase):
         res = enhanceRecord(testRec)
         self.assertFalse(res)
         self.assertRaises(OCLCError)
-
-    @patch('lib.enhancer.Agent.checkForMatches', return_value=['agent', 'author2'])
-    def test_merge(self, mock_matches):
-        source = {
-            'title': 'Source Test',
-            'altTitle': ['Source Alt'],
-            'instances': ['instance'],
-            'agents': ['agent'],
-            'subjects': ['subject'],
-            'measurements': ['measurement']
-        }
-
-        oclcSource = WorkRecord.createFromDict(**{
-            'workTitle': 'OCLC Title',
-            'altTitles': ['OCLC Alt'],
-            'editions': ['instance2'],
-            'authors': ['author2'],
-            'subjects': ['subject2'],
-            'measurements': ['mesurement2']
-        })
-
-        data = mergeData(source, oclcSource)
-        self.assertEqual(data['title'], 'OCLC Title')
-        self.assertEqual(data['agents'], ['agent', 'author2'])

--- a/tests/test_kinesis.py
+++ b/tests/test_kinesis.py
@@ -20,14 +20,14 @@ class TestKinesis(unittest.TestCase):
             'SequenceNumber': '0'
         }
 
-        record = {'test': 'data'}
-
-        body = json.dumps({
+        record = {
             'status': 200,
             'type': 'work',
             'method': 'update',
-            'data': record
-        })
+            'data': {'test': 'data'}
+        }
+
+        body = json.dumps(record)
 
         expected_params = {
             'Data': body,

--- a/tests/test_kinesis.py
+++ b/tests/test_kinesis.py
@@ -24,20 +24,21 @@ class TestKinesis(unittest.TestCase):
 
         body = json.dumps({
             'status': 200,
-            'stage': 'test',
+            'type': 'work',
+            'method': 'update',
             'data': record
         })
 
         expected_params = {
             'Data': body,
-            'StreamName': 'tester',
+            'StreamName': 'testStream',
             'PartitionKey': '0'
         }
 
         stubber.add_response('put_record', expResp, expected_params)
         stubber.activate()
 
-        kinesis.putRecord(record)
+        kinesis.putRecord(record, 'testStream')
 
     @patch.dict('os.environ', {'OUTPUT_KINESIS': 'tester', 'OUTPUT_SHARD': '0', 'OUTPUT_STAGE': 'test'})
     def test_putRecord_err(self):
@@ -61,7 +62,7 @@ class TestKinesis(unittest.TestCase):
         stubber.add_client_error('put_record', expected_params=expected_params)
         stubber.activate()
         try:
-            kinesis.putRecord(record)
+            kinesis.putRecord(record, 'testStream')
         except KinesisError:
             pass
         self.assertRaises(KinesisError)

--- a/tests/test_parseOCLC.py
+++ b/tests/test_parseOCLC.py
@@ -1,12 +1,23 @@
+from lxml import etree
 import unittest
-from unittest.mock import patch, mock_open, call
+from unittest.mock import MagicMock, Mock
 
 from lib.parsers.parseOCLC import readFromClassify
+from lib.dataModel import WorkRecord
 
 class TestOCLCParse(unittest.TestCase):
 
-    @patch('lib.parsers.parseOCLC.parseWork', return_value=True)
-    def test_classify_read(self, mock_parse):
-        res = readFromClassify(['some', 'data'])
-        mock_parse.assert_called_once()
-        self.assertTrue(res)
+    def test_classify_read(self):
+        mockXML = Mock()
+        work = etree.Element('work',
+            title='Test Work',
+            editions='1',
+            holdings='1',
+            eholdings='1',
+            owi='1111111',
+        )
+        work.text = '0000000000'
+        mockXML.find = MagicMock(return_value=work)
+        mockXML.findall = MagicMock(return_value=[])
+        res = readFromClassify(mockXML)
+        self.assertIsInstance(res, WorkRecord)

--- a/tests/test_parseOCLC.py
+++ b/tests/test_parseOCLC.py
@@ -1,20 +1,12 @@
 import unittest
 from unittest.mock import patch, mock_open, call
 
-from lib.parsers.parseOCLC import readFromClassify, extractFromXML, parseWork
+from lib.parsers.parseOCLC import readFromClassify
 
 class TestOCLCParse(unittest.TestCase):
 
-    @patch('lib.parsers.parseOCLC.extractFromXML')
-    @patch('lib.parsers.parseOCLC.combineData', return_value=True)
-    def test_classify_read(self, mock_combine, mock_xml):
-        res = readFromClassify(['some', 'data'])
-        mock_combine.assert_called_once()
-        mock_xml.assert_called_once()
-        self.assertTrue(res)
-
     @patch('lib.parsers.parseOCLC.parseWork', return_value=True)
-    def test_xml_extract(self, mock_parse):
-        res = extractFromXML(['data1', 'data2'])
-        mock_parse.assert_has_calls([call('data1'), call('data2')])
-        self.assertEqual(res, [True, True])
+    def test_classify_read(self, mock_parse):
+        res = readFromClassify(['some', 'data'])
+        mock_parse.assert_called_once()
+        self.assertTrue(res)


### PR DESCRIPTION
After several discussions and a review of the overall architecture, it seems more prudent to simply have this service fetch data and return it for further processing, rather than attempt to manage data merging and updates. As this is an intermediate step that risked losing sight of what changes were made to the data as well as loosing the ability to trace the source of all data in the system.

This update makes the service simpler, enabling queries to be made against the Classify service using either a title/author search or a search by identifier (oclc#, lccn, etc.) The function transforms the received XML document into an object that complies with the SFR data model (as defined in the dataModel.py file in this repository). That object is then returned to a stream for persistence to the db.