### PR TITLE
Fix credentials for event source mapping

### DIFF
--- a/helpers/configHelpers.py
+++ b/helpers/configHelpers.py
@@ -17,6 +17,8 @@ def loadEnvFile(runType, fileString):
         openFile = fileString.format(runType)
     else:
         openFile = 'config.yaml'
+        if os.path.isfile('run_config.yaml'):
+            openFile = 'run_config.yaml'
 
     try:
         with open(openFile) as envStream:

--- a/scripts/lambdaRun.py
+++ b/scripts/lambdaRun.py
@@ -41,8 +41,8 @@ def main():
             '--requirements',
             'requirements.txt'
         ])
-        os.remove('run_config.yaml')
         createEventMapping(runType)
+        os.remove('run_config.yaml')
 
     elif re.match(r'^run-local', runType):
         logger.info('Running test locally with development environment')


### PR DESCRIPTION
The main lambda deployment was receiving the credentials, but they were not being passed to the boto3 client. This should check the proper file where they are populated.