### PR TITLE
Fix empty author/title string parsing

### DIFF
--- a/lib/dataModel.py
+++ b/lib/dataModel.py
@@ -173,12 +173,12 @@ class Identifier(DataObject):
 
 
 class Link(DataObject):
-    def __init__(self, url=None, mediaType=None, relType=None):
+    def __init__(self, url=None, mediaType=None, flags=None):
         super()
         self.url = url
         self.media_type = mediaType
         self.content = None
-        self.rel_type = None
+        self.flags = None
         self.thumbnail = None
 
 

--- a/lib/readers/oclcClassify.py
+++ b/lib/readers/oclcClassify.py
@@ -139,8 +139,8 @@ class QueryManager():
         self.searchType = searchType
         self.recID = recID
         self.recType = recType
-        self.author = author
-        self.title = title
+        self.author = QueryManager.parseString(author)
+        self.title = QueryManager.parseString(title)
         self.query = None
 
     def generateQueryURL(self):
@@ -228,3 +228,11 @@ class QueryManager():
             raise OCLCError('Failed to reach OCLC Classify Service')
 
         return classifyResp.text
+    
+    @classmethod
+    def parseString(cls, string):
+        if isinstance(string, str):
+            cleanString = string.strip()
+            return cleanString if cleanString != '' else None
+        
+        return string

--- a/tests/test_classifyOCLC.py
+++ b/tests/test_classifyOCLC.py
@@ -66,12 +66,15 @@ class TestOCLCClassify(unittest.TestCase):
         mock_clean.assert_called_once()
     
     def test_author_missing(self):
-        testQuery = QueryManager(None, None, None, None, 'Sole Title')
-        try:
+        with self.assertRaises(DataError):
+            testQuery = QueryManager(None, None, None, None, 'Sole Title')
             testQuery.generateAuthorTitleURL()
-        except DataError:
-            pass
-        self.assertRaises(DataError)
+
+    def test_author_missing_empty_string(self):
+        with self.assertRaises(DataError):
+            testQuery = QueryManager(None, None, None, '', 'Sole Title')
+            testQuery.generateAuthorTitleURL()
+            
     
     @patch('lib.readers.oclcClassify.QueryManager.addClassifyOptions')
     def test_identifier_generate(self, mock_add):


### PR DESCRIPTION
This function was parsing empty strings as valid authors and titles for the purposes of querying the Classify service. However, Classify treats an empty string as no value, which was returning erronous results (Far too many matches for generic titles usually) A previous fix was intended to prevent this, but failed to catch these cases (only catching cases of `None`).

An additional test was added to ensure that empty strings throw an error