### PR TITLE
Sfr 703 internal execution

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,8 +12,8 @@ aws_access_key_id:
 aws_secret_access_key:
 
 # dist_directory: dist
-timeout: 120
-memory_size: 128
+timeout: 300 
+memory_size: 512
 
 
 # If `tags` is uncommented then tags will be set at creation or update

--- a/lib/enhancer.py
+++ b/lib/enhancer.py
@@ -34,7 +34,7 @@ def enhanceRecord(record):
         classifyData = classifyRecord(searchType, searchFields, workUUID)
 
         # Step 2: Parse the data recieved from Classify into the SFR data model
-        parsedData = readFromClassify(classifyData)
+        parsedData = readFromClassify(classifyData, workUUID)
 
         # This sets the primary identifier for processing by the db manager
         parsedData.primary_identifier = Identifier('uuid', workUUID, 1)
@@ -46,7 +46,7 @@ def enhanceRecord(record):
             'method': 'update',
             'data': parsedData
         }
-        OutputManager.putKinesis(outputObject, os.environ['OUTPUT_KINESIS'])
+        OutputManager.putKinesis(outputObject, os.environ['OUTPUT_KINESIS'], workUUID)
 
     except OCLCError as err:
         logger.error('OCLC Query for work {} failed with message: {}'.format(workUUID, err.message))

--- a/lib/enhancer.py
+++ b/lib/enhancer.py
@@ -46,7 +46,24 @@ def enhanceRecord(record):
             'method': 'update',
             'data': parsedData
         }
-        OutputManager.putKinesis(outputObject, os.environ['OUTPUT_KINESIS'], workUUID)
+        while len(parsedData.instances) > 100:
+            instanceChunk = parsedData.instances[0:100]
+            del parsedData.instances[0:100]
+            OutputManager.putKinesis(
+                {
+                    'status': 200,
+                    'type': 'work',
+                    'method': 'update',
+                    'data': {
+                        'instances': instanceChunk,
+                        'primary_identifier': Identifier('uuid', workUUID, 1)
+                    }
+                },
+                os.environ['OUTPUT_KINESIS'],
+                workUUID
+            )
+
+        # OutputManager.putKinesis(outputObject, os.environ['OUTPUT_KINESIS'], workUUID)
 
     except OCLCError as err:
         logger.error('OCLC Query for work {} failed with message: {}'.format(workUUID, err.message))

--- a/lib/enhancer.py
+++ b/lib/enhancer.py
@@ -63,7 +63,7 @@ def enhanceRecord(record):
                 workUUID
             )
 
-        # OutputManager.putKinesis(outputObject, os.environ['OUTPUT_KINESIS'], workUUID)
+        OutputManager.putKinesis(outputObject, os.environ['OUTPUT_KINESIS'], workUUID)
 
     except OCLCError as err:
         logger.error('OCLC Query for work {} failed with message: {}'.format(workUUID, err.message))

--- a/lib/outputManager.py
+++ b/lib/outputManager.py
@@ -29,7 +29,7 @@ class OutputManager():
         pass
 
     @classmethod
-    def putKinesis(cls, data, stream):
+    def putKinesis(cls, data, stream, uuid):
         """Puts records into a Kinesis stream for processing by other parts of
         the SFR data pipeline. Takes data as an object and converts it into a
         JSON string. This is then passed to the specified stream.
@@ -43,11 +43,6 @@ class OutputManager():
             'data': data
         }
 
-        try:
-            partKey = data['data'].identifiers[0].identifier
-        except KeyError:
-            partKey = data['fields']['identifier']
-
         # The default lambda function here converts all objects into dicts
         kinesisStream = OutputManager._convertToJSON(outputObject)
         
@@ -55,7 +50,7 @@ class OutputManager():
             cls.KINESIS_CLIENT.put_record(
                 StreamName=stream,
                 Data=kinesisStream,
-                PartitionKey=partKey
+                PartitionKey=uuid
             )
 
         except:

--- a/lib/outputManager.py
+++ b/lib/outputManager.py
@@ -45,7 +45,7 @@ class OutputManager():
 
         # The default lambda function here converts all objects into dicts
         kinesisStream = OutputManager._convertToJSON(outputObject)
-        
+
         try:
             cls.KINESIS_CLIENT.put_record(
                 StreamName=stream,
@@ -53,8 +53,9 @@ class OutputManager():
                 PartitionKey=uuid
             )
 
-        except:
+        except Exception as err:
             logger.error('Kinesis Write error!')
+            logger.debug(err)
             raise OutputError('Failed to write result to output stream!')
 
     @classmethod

--- a/lib/parsers/parseOCLC.py
+++ b/lib/parsers/parseOCLC.py
@@ -38,9 +38,9 @@ def readFromClassify(workXML, workUUID):
     oclcNo = Identifier('oclc', work.text, 1)
     owiNo = Identifier('owi', work.get('owi'), 1)
 
-    if OutputManager.checkRecentQueries('lookup/{}/{}'.format('owi', owiNo)) is True:
+    if OutputManager.checkRecentQueries('lookup/{}/{}'.format('owi', work.get('owi'))) is True:
         raise DataError('Work {} with OWI {} already classified'.format(
-            workUUID, owiNo
+            workUUID, work.get('owi')
         ))
 
     measurements = []

--- a/lib/parsers/parseOCLC.py
+++ b/lib/parsers/parseOCLC.py
@@ -109,7 +109,6 @@ def loadEditions(editions, uuid):
     while outQueue.empty() is False:
         outEds.append(outQueue.get())
 
-    print(outEds)
     return outEds
 
 

--- a/lib/parsers/parseOCLC.py
+++ b/lib/parsers/parseOCLC.py
@@ -108,6 +108,7 @@ def loadEditions(editions, uuid):
         processes.append(proc)
         outPipes.append(pConn)
         proc.start()
+        cConn.close()
 
     for proc in processes:
         proc.join()

--- a/tests/test_kinesis.py
+++ b/tests/test_kinesis.py
@@ -20,11 +20,8 @@ class TestKinesis(unittest.TestCase):
             'ShardId': '1',
             'SequenceNumber': '0'
         }
-        mock_id = MagicMock()
-        mock_id.identifier = 'test'
         mock_data = MagicMock()
         mock_data.test = 'data'
-        mock_data.identifiers = [mock_id]
         record = {
             'type': 'work',
             'method': 'update',
@@ -34,13 +31,13 @@ class TestKinesis(unittest.TestCase):
         expected_params = {
             'Data': 'testing',
             'StreamName': 'testStream',
-            'PartitionKey': 'test'
+            'PartitionKey': 'testUUID'
         }
 
         stubber.add_response('put_record', expResp, expected_params)
         stubber.activate()
 
-        kinesis.putKinesis(record, 'testStream')
+        kinesis.putKinesis(record, 'testStream', 'testUUID')
 
     @patch.dict('os.environ', {'OUTPUT_KINESIS': 'tester', 'OUTPUT_SHARD': '0', 'OUTPUT_STAGE': 'test'})
     @patch('lib.outputManager.OutputManager._convertToJSON', return_value='testing')
@@ -48,11 +45,8 @@ class TestKinesis(unittest.TestCase):
         kinesis = OutputManager()
         stubber = Stubber(kinesis.KINESIS_CLIENT)
 
-        mock_id = MagicMock()
-        mock_id.identifier = 'test'
         mock_data = MagicMock()
         mock_data.test = 'data'
-        mock_data.identifiers = [mock_id]
         record = {
             'type': 'work',
             'method': 'update',
@@ -62,13 +56,13 @@ class TestKinesis(unittest.TestCase):
         expected_params = {
             'Data': 'testing',
             'StreamName': 'tester',
-            'PartitionKey': '0'
+            'PartitionKey': 'testUUID'
         }
 
         stubber.add_client_error('put_record', expected_params=expected_params)
         stubber.activate()
         try:
-            kinesis.putKinesis(record, 'testStream')
+            kinesis.putKinesis(record, 'testStream', 'testUUID')
         except OutputError:
             pass
         self.assertRaises(OutputError)

--- a/tests/test_parseOCLC.py
+++ b/tests/test_parseOCLC.py
@@ -19,5 +19,5 @@ class TestOCLCParse(unittest.TestCase):
         work.text = '0000000000'
         mockXML.find = MagicMock(return_value=work)
         mockXML.findall = MagicMock(return_value=[])
-        res = readFromClassify(mockXML)
+        res = readFromClassify(mockXML, 'testUUID')
         self.assertIsInstance(res, WorkRecord)

--- a/tests/test_parseOCLC.py
+++ b/tests/test_parseOCLC.py
@@ -1,13 +1,15 @@
 from lxml import etree
 import unittest
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, patch
 
 from lib.parsers.parseOCLC import readFromClassify
 from lib.dataModel import WorkRecord
+from lib.outputManager import OutputManager
 
 class TestOCLCParse(unittest.TestCase):
 
-    def test_classify_read(self):
+    @patch.object(OutputManager, 'checkRecentQueries', return_value=False)
+    def test_classify_read(self, mockCheck):
         mockXML = Mock()
         work = etree.Element('work',
             title='Test Work',
@@ -21,3 +23,4 @@ class TestOCLCParse(unittest.TestCase):
         mockXML.findall = MagicMock(return_value=[])
         res = readFromClassify(mockXML, 'testUUID')
         self.assertIsInstance(res, WorkRecord)
+        mockCheck.assert_called_once_with('lookup/owi/1111111')


### PR DESCRIPTION
Instead of parsing the Classify response for editions and passing the resulting list to a queue for asynchronous parsing, this moves the parsing of this list to a multithreaded module within this function. This will have the effect of moving the work of merging the work and instance records from the database update function to here, instituting a better division of concerns and potentially providing a large performance boost.

This will make this function run at a significantly reduced speed, so it should have a higher memory provision, though with concurrent executions, we should see no significant slowdown in the overall processing time.