### PR TITLE
SFR-703 all editions fetch

### DIFF
--- a/lib/enhancer.py
+++ b/lib/enhancer.py
@@ -35,7 +35,7 @@ def enhanceRecord(record):
 
         # Step 2: Parse the data recieved from Classify into the SFR data model
         classifiedWork, instanceCount = readFromClassify(classifyData, workUUID)
-
+        logger.debug('Instances found {}'.format(instanceCount))
         if instanceCount > 500:
             for i in range(500, instanceCount, 500):
                 classifyPage = classifyRecord(

--- a/lib/enhancer.py
+++ b/lib/enhancer.py
@@ -4,7 +4,7 @@ from helpers.errorHelpers import OCLCError, DataError
 from helpers.logHelpers import createLog
 from lib.dataModel import Agent, Identifier
 from lib.readers.oclcClassify import classifyRecord
-from lib.parsers.parseOCLC import readFromClassify
+from lib.parsers.parseOCLC import readFromClassify, extractAndAppendEditions
 from lib.outputManager import OutputManager
 
 logger = createLog('enhancer')
@@ -34,21 +34,28 @@ def enhanceRecord(record):
         classifyData = classifyRecord(searchType, searchFields, workUUID)
 
         # Step 2: Parse the data recieved from Classify into the SFR data model
-        parsedData = readFromClassify(classifyData, workUUID)
+        classifiedWork, instanceCount = readFromClassify(classifyData, workUUID)
+
+        if instanceCount > 500:
+            for i in range(500, instanceCount, 500):
+                classifyPage = classifyRecord(
+                    searchType, searchFields, workUUID, start=i
+                )
+                extractAndAppendEditions(classifiedWork, classifyPage)
 
         # This sets the primary identifier for processing by the db manager
-        parsedData.primary_identifier = Identifier('uuid', workUUID, 1)
+        classifiedWork.primary_identifier = Identifier('uuid', workUUID, 1)
 
         # Step 3: Output this block to kinesis
         outputObject = {
             'status': 200,
             'type': 'work',
             'method': 'update',
-            'data': parsedData
+            'data': classifiedWork
         }
-        while len(parsedData.instances) > 100:
-            instanceChunk = parsedData.instances[0:100]
-            del parsedData.instances[0:100]
+        while len(classifiedWork.instances) > 100:
+            instanceChunk = classifiedWork.instances[0:100]
+            del classifiedWork.instances[0:100]
             OutputManager.putKinesis(
                 {
                     'status': 200,
@@ -62,7 +69,6 @@ def enhanceRecord(record):
                 os.environ['OUTPUT_KINESIS'],
                 workUUID
             )
-
         OutputManager.putKinesis(outputObject, os.environ['OUTPUT_KINESIS'], workUUID)
 
     except OCLCError as err:

--- a/lib/parsers/parseOCLC.py
+++ b/lib/parsers/parseOCLC.py
@@ -57,7 +57,7 @@ def readFromClassify(workXML, workUUID):
     authorList = list(map(parseAuthor, authors))
 
     editions = workXML.findall('.//edition', namespaces=NAMESPACE)
-    editionList = loadEditions(editions, workUUID)
+    editionList = loadEditions(editions)
 
     headings = workXML.findall('.//heading', namespaces=NAMESPACE)
     headingList = list(map(parseHeading, headings))
@@ -75,6 +75,11 @@ def readFromClassify(workXML, workUUID):
     }
 
     return WorkRecord.createFromDict(**workDict)
+
+
+def extractAndAppendEditions(work, classifyXML):
+    editions = classifyXML.findall('.//edition', namespaces=NAMESPACE)
+    work.instances.extend(loadEditions(editions))
 
 
 def parseHeading(heading):
@@ -96,7 +101,7 @@ def parseHeading(heading):
     return subject
 
 
-def loadEditions(editions, uuid):
+def loadEditions(editions):
     processes = []
     outPipes = []
     cores = 4

--- a/lib/parsers/parseOCLC.py
+++ b/lib/parsers/parseOCLC.py
@@ -74,7 +74,9 @@ def readFromClassify(workXML, workUUID):
         'measurements': measurements
     }
 
-    return WorkRecord.createFromDict(**workDict)
+    instanceCount = int(work.get('editions', 0))
+
+    return WorkRecord.createFromDict(**workDict), instanceCount
 
 
 def extractAndAppendEditions(work, classifyXML):
@@ -152,7 +154,12 @@ copyreg.pickle(etree._Element, etreePickler, etreeUnPickler)
 
 def parseChunk(editions, cConn):
     for edition in editions:
-        cConn.send(parseEdition(edition))
+        try:
+            editionData = parseEdition(edition)
+            cConn.send(editionData)
+        except Exception as err:
+            logger.error('Unable to parse edition, skipping')
+            logger.debug(err)
 
     cConn.send('DONE')
     cConn.close()

--- a/lib/readers/oclcClassify.py
+++ b/lib/readers/oclcClassify.py
@@ -14,7 +14,7 @@ NAMESPACE = {
 }
 
 
-def classifyRecord(searchType, searchFields, workUUID):
+def classifyRecord(searchType, searchFields, workUUID, start=0):
     """Generates a query for the OCLC Classify service and returns the raw
     XML response received from that service. This method takes 3 arguments:
     - searchType: identifier|authorTitle
@@ -26,7 +26,8 @@ def classifyRecord(searchType, searchFields, workUUID):
             searchFields.get('identifier', None),
             searchFields.get('idType', None),
             searchFields.get('authors', None),
-            searchFields.get('title', None)
+            searchFields.get('title', None),
+            start
         )
         classifyQuery.generateQueryURL()
         logger.info('Fetching data for url: {}'.format(classifyQuery.query))
@@ -156,13 +157,14 @@ class QueryManager():
         'stdnbr'# Sandard Number (unclear)
     ]
 
-    def __init__(self, searchType, recID, recType, author, title):
+    def __init__(self, searchType, recID, recType, author, title, start):
         self.searchType = searchType
         self.recID = recID
         self.recType = recType
         self.author = QueryManager.parseString(author)
         self.title = QueryManager.parseString(title)
         self.query = None
+        self.start = start
 
     def generateQueryURL(self):
         """Parses the received data and generates a Classify query based either
@@ -231,7 +233,9 @@ class QueryManager():
         single work response and "maxRecs" controls the upper limit on the
         number of possible editions returned with a work.
         """
-        self.query = '{}&summary=false&maxRecs=500'.format(self.query)
+        self.query = '{}&summary=false&startRec={}&maxRecs=500'.format(
+            self.query, self.start
+        )
 
     def execQuery(self):
         """Executes the constructed query against the OCLC endpoint

--- a/tests/test_classifyOCLC.py
+++ b/tests/test_classifyOCLC.py
@@ -13,7 +13,8 @@ class TestOCLCClassify(unittest.TestCase):
             'testID',
             'testType',
             'testAuthor',
-            'testTitle'
+            'testTitle',
+            0
         )
         self.assertEqual(testQuery.title, 'testTitle')
         self.assertEqual(testQuery.query, None)
@@ -26,7 +27,8 @@ class TestOCLCClassify(unittest.TestCase):
             'testID',
             'testType',
             'testAuthor',
-            'testTitle'
+            'testTitle',
+            0
         )
         testQuery.generateQueryURL()
         mock_title.assert_called_once()
@@ -40,7 +42,8 @@ class TestOCLCClassify(unittest.TestCase):
             'testID',
             'testType',
             'testAuthor',
-            'testTitle'
+            'testTitle',
+            0
         )
         testQuery.generateQueryURL()
         mock_id.assert_called_once()
@@ -48,14 +51,14 @@ class TestOCLCClassify(unittest.TestCase):
     
     def test_clean_title(self):
         rawTitle = ' Hello\r weird\n title thingy '
-        testQuery = QueryManager(None, None, None, None, rawTitle)
+        testQuery = QueryManager(None, None, None, None, rawTitle, 0)
         testQuery.cleanTitle()
         self.assertEqual(testQuery.title, 'Hello weird title thingy')
     
     @patch('lib.readers.oclcClassify.QueryManager.cleanTitle')
     @patch('lib.readers.oclcClassify.QueryManager.addClassifyOptions')
     def test_author_generate(self, mock_add, mock_clean):
-        testQuery = QueryManager(None, None, None, 'Tester', 'Test Title')
+        testQuery = QueryManager(None, None, None, 'Tester', 'Test Title', 0)
         testQuery.generateAuthorTitleURL()
 
         self.assertEqual(
@@ -67,18 +70,18 @@ class TestOCLCClassify(unittest.TestCase):
     
     def test_author_missing(self):
         with self.assertRaises(DataError):
-            testQuery = QueryManager(None, None, None, None, 'Sole Title')
+            testQuery = QueryManager(None, None, None, None, 'Sole Title', 0)
             testQuery.generateAuthorTitleURL()
 
     def test_author_missing_empty_string(self):
         with self.assertRaises(DataError):
-            testQuery = QueryManager(None, None, None, '', 'Sole Title')
+            testQuery = QueryManager(None, None, None, '', 'Sole Title', 0)
             testQuery.generateAuthorTitleURL()
             
     
     @patch('lib.readers.oclcClassify.QueryManager.addClassifyOptions')
     def test_identifier_generate(self, mock_add):
-        testQuery = QueryManager(None, 'testID', 'isbn', None, None)
+        testQuery = QueryManager(None, 'testID', 'isbn', None, None, 0)
         testQuery.generateIdentifierURL()
 
         self.assertEqual(
@@ -89,13 +92,13 @@ class TestOCLCClassify(unittest.TestCase):
     
     @patch('lib.readers.oclcClassify.QueryManager.generateAuthorTitleURL')
     def test_identifier_none(self, mock_author):
-        testQuery = QueryManager(None, None, None, None, None)
+        testQuery = QueryManager(None, None, None, None, None, 0)
         testQuery.generateIdentifierURL()
 
         mock_author.asert_called_once()
     
     def test_identifier_error(self):
-        testQuery = QueryManager(None, 'testID', 'testType', None, None)
+        testQuery = QueryManager(None, 'testID', 'testType', None, None, 0)
         try:
             testQuery.generateIdentifierURL()
         except DataError:
@@ -103,12 +106,12 @@ class TestOCLCClassify(unittest.TestCase):
         self.assertRaises(DataError)
     
     def test_add_options(self):
-        testQuery = QueryManager(None, None, None, None, None)
+        testQuery = QueryManager(None, None, None, None, None, 0)
         testQuery.query = 'testQuery'
         testQuery.addClassifyOptions()
         self.assertEqual(
             testQuery.query,
-            'testQuery&summary=false&maxRecs=500'
+            'testQuery&summary=false&startRec=0&maxRecs=500'
         )
     
     @patch('lib.readers.oclcClassify.requests')
@@ -118,7 +121,7 @@ class TestOCLCClassify(unittest.TestCase):
         mock_resp.text = 'testing'
         mock_requests.get.return_value = mock_resp
         
-        testQuery = QueryManager(None, None, None, None, None)
+        testQuery = QueryManager(None, None, None, None, None, 0)
         testRes = testQuery.execQuery()
         self.assertEqual(testRes, 'testing')
 
@@ -129,7 +132,7 @@ class TestOCLCClassify(unittest.TestCase):
         mock_resp.text = 'testing'
         mock_requests.get.return_value = mock_resp
         
-        testQuery = QueryManager(None, None, None, None, None)
+        testQuery = QueryManager(None, None, None, None, None, 0)
         
         try:
             testQuery.execQuery()

--- a/tests/test_parseOCLC.py
+++ b/tests/test_parseOCLC.py
@@ -2,16 +2,17 @@ from lxml import etree
 import unittest
 from unittest.mock import MagicMock, Mock, patch
 
-from lib.parsers.parseOCLC import readFromClassify
+from lib.parsers.parseOCLC import readFromClassify, loadEditions, extractAndAppendEditions
 from lib.dataModel import WorkRecord
 from lib.outputManager import OutputManager
 
-class TestOCLCParse(unittest.TestCase):
 
+class TestOCLCParse(unittest.TestCase):
     @patch.object(OutputManager, 'checkRecentQueries', return_value=False)
     def test_classify_read(self, mockCheck):
         mockXML = Mock()
-        work = etree.Element('work',
+        work = etree.Element(
+            'work',
             title='Test Work',
             editions='1',
             holdings='1',
@@ -24,3 +25,20 @@ class TestOCLCParse(unittest.TestCase):
         res = readFromClassify(mockXML, 'testUUID')
         self.assertIsInstance(res, WorkRecord)
         mockCheck.assert_called_once_with('lookup/owi/1111111')
+
+    @patch('lib.parsers.parseOCLC.parseEdition', return_value=True)
+    def test_loadEditions(self, mockParse):
+        testEditions = [i for i in range(16)]
+        outEds = loadEditions(testEditions)
+        self.assertEqual(len(outEds), 16)
+    
+    @patch('lib.parsers.parseOCLC.loadEditions')
+    def test_extractEditions(self, mockLoad):
+        mockXML = MagicMock()
+        mockXML.findall.return_value = ['ed1', 'ed2', 'ed3']
+        mockWork = MagicMock()
+        mockWork.instances = []
+        mockLoad.return_value = [1, 2, 3]
+        extractAndAppendEditions(mockWork, mockXML)
+        self.assertEqual(mockWork.instances, [1, 2, 3])
+        mockLoad.assert_called_once_with(['ed1', 'ed2', 'ed3'])

--- a/tests/test_parseOCLC.py
+++ b/tests/test_parseOCLC.py
@@ -22,8 +22,9 @@ class TestOCLCParse(unittest.TestCase):
         work.text = '0000000000'
         mockXML.find = MagicMock(return_value=work)
         mockXML.findall = MagicMock(return_value=[])
-        res = readFromClassify(mockXML, 'testUUID')
-        self.assertIsInstance(res, WorkRecord)
+        resWork, resCount = readFromClassify(mockXML, 'testUUID')
+        self.assertIsInstance(resWork, WorkRecord)
+        self.assertEqual(resCount, 1)
         mockCheck.assert_called_once_with('lookup/owi/1111111')
 
     @patch('lib.parsers.parseOCLC.parseEdition', return_value=True)


### PR DESCRIPTION
Previously this was only fetching the top 500 editions of a work (sorted by the number of holdings). While this is adequate in 99% of the cases we are fetching data, it does not include all data for historically very popular works (e.g. a work by Dickens or Shakespeare).

This adds a conditional check for the number of editions associated with a work record and includes additional "paged" calls to get all of the associated works. This is not limited, so it should work in all cases. The highest number of editions are associated with Don Quixote, at around 12,000. While that may pose some timeout issues with this function, everything is broken into smaller pieces for writing to the database, so there should be no downstream side effects except for a slightly increased processing time to handle the increased edition records.