### PR TITLE
HOTFIX Split Large Works

### DIFF
--- a/lib/enhancer.py
+++ b/lib/enhancer.py
@@ -2,12 +2,13 @@ import os
 
 from helpers.errorHelpers import OCLCError, DataError
 from helpers.logHelpers import createLog
-from lib.dataModel import Agent, Identifier
+from lib.dataModel import Identifier
 from lib.readers.oclcClassify import classifyRecord
 from lib.parsers.parseOCLC import readFromClassify, extractAndAppendEditions
 from lib.outputManager import OutputManager
 
 logger = createLog('enhancer')
+
 
 def enhanceRecord(record):
     """Takes a single input record and retrieves data from the OCLC Classify
@@ -17,6 +18,7 @@ def enhanceRecord(record):
         workUUID = record['uuid']
         searchType = record['type']
         searchFields = record['fields']
+        startPos = record.get('start', 0)
     except KeyError as e:
         logger.error('Missing attribute in data block!')
         logger.debug(e)
@@ -31,17 +33,35 @@ def enhanceRecord(record):
     try:
         # Step 1: Generate a set of XML records retrieved from Classify
         # This step also adds the oclc identifiers to the sourceData record
-        classifyData = classifyRecord(searchType, searchFields, workUUID)
+        classifyData = classifyRecord(
+            searchType, searchFields, workUUID, start=startPos
+        )
 
         # Step 2: Parse the data recieved from Classify into the SFR data model
-        classifiedWork, instanceCount = readFromClassify(classifyData, workUUID)
+        classifiedWork, instanceCount, oclcNo = readFromClassify(
+            classifyData, workUUID
+        )
         logger.debug('Instances found {}'.format(instanceCount))
         if instanceCount > 500:
-            for i in range(500, instanceCount, 500):
+            iterStop = startPos + instanceCount
+            if instanceCount > 1500:
+                iterStop = startPos + 1500
+            for i in range(startPos + 500, iterStop, 500):
                 classifyPage = classifyRecord(
                     searchType, searchFields, workUUID, start=i
                 )
                 extractAndAppendEditions(classifiedWork, classifyPage)
+
+        if instanceCount > startPos + 1500:
+            OutputManager.putQueue({
+                'type': 'identifier',
+                'uuid': workUUID,
+                'fields': {
+                    'idType': 'oclc',
+                    'identifier': oclcNo,
+                    'start': startPos + 1500
+                }
+            }, os.environ['CLASSIFY_QUEUE'])
 
         # This sets the primary identifier for processing by the db manager
         classifiedWork.primary_identifier = Identifier('uuid', workUUID, 1)
@@ -69,10 +89,14 @@ def enhanceRecord(record):
                 os.environ['OUTPUT_KINESIS'],
                 workUUID
             )
-        OutputManager.putKinesis(outputObject, os.environ['OUTPUT_KINESIS'], workUUID)
+        OutputManager.putKinesis(
+            outputObject, os.environ['OUTPUT_KINESIS'], workUUID
+        )
 
     except OCLCError as err:
-        logger.error('OCLC Query for work {} failed with message: {}'.format(workUUID, err.message))
+        logger.error('OCLC Query for work {} failed with message: {}'.format(
+            workUUID, err.message
+        ))
         raise err
 
     return True

--- a/lib/parsers/parseOCLC.py
+++ b/lib/parsers/parseOCLC.py
@@ -76,7 +76,7 @@ def readFromClassify(workXML, workUUID):
 
     instanceCount = int(work.get('editions', 0))
 
-    return WorkRecord.createFromDict(**workDict), instanceCount
+    return WorkRecord.createFromDict(**workDict), instanceCount, work.text
 
 
 def extractAndAppendEditions(work, classifyXML):

--- a/tests/test_enhancer.py
+++ b/tests/test_enhancer.py
@@ -20,7 +20,7 @@ class TestEnhancer(unittest.TestCase):
         }
         mockWork = MagicMock()
         mockWork.instances = [1, 2, 3]
-        mock_read.return_value = (mockWork, 3)
+        mock_read.return_value = (mockWork, 3, 123456)
 
         res = enhanceRecord(testRec)
         self.assertTrue(res)
@@ -48,7 +48,7 @@ class TestEnhancer(unittest.TestCase):
         }
         mockWork = MagicMock()
         mockWork.instances = [True] * 600
-        mockRead.return_value = (mockWork, 600)
+        mockRead.return_value = (mockWork, 600, 123456)
 
         res = enhanceRecord(testRec)
 
@@ -58,6 +58,58 @@ class TestEnhancer(unittest.TestCase):
         self.assertEqual(len(mockPut.mock_calls), 6)
         self.assertTrue(res)
 
+    @patch.dict('os.environ', {'CLASSIFY_QUEUE': 'testQ', 'OUTPUT_KINESIS': 'tester', 'OUTPUT_REGION': 'us-test-1'})
+    @patch('lib.enhancer.extractAndAppendEditions')
+    @patch('lib.enhancer.OutputManager.putKinesis')
+    @patch('lib.enhancer.OutputManager.putQueue')
+    @patch('lib.enhancer.readFromClassify')
+    @patch('lib.enhancer.classifyRecord')
+    def test_enhancer_1500_plus(self, mockClassify, mockRead, mockSQS, mockPut, mockExtract):
+        testRec = {
+            'uuid': '11111111-1111-1111-1111-111111111111',
+            'type': 'test',
+            'fields': {
+                'test': 'test'
+            }
+        }
+        mockWork = MagicMock()
+        mockWork.instances = [True] * 1500
+        mockRead.return_value = (mockWork, 1600, 123456)
+
+        res = enhanceRecord(testRec)
+
+        self.assertEqual(len(mockClassify.mock_calls), 3)
+        mockRead.assert_called_once()
+        self.assertEqual(len(mockExtract.mock_calls), 2)
+        mockSQS.assert_called_once()
+        self.assertEqual(len(mockPut.mock_calls), 15)
+        self.assertTrue(res)
+
+    @patch.dict('os.environ', {'OUTPUT_KINESIS': 'tester', 'OUTPUT_REGION': 'us-test-1'})
+    @patch('lib.enhancer.extractAndAppendEditions')
+    @patch('lib.enhancer.OutputManager.putKinesis')
+    @patch('lib.enhancer.readFromClassify')
+    @patch('lib.enhancer.classifyRecord')
+    def test_enhancer_1500_start(self, mockClassify, mockRead, mockPut, mockExtract):
+        testRec = {
+            'uuid': '11111111-1111-1111-1111-111111111111',
+            'type': 'test',
+            'fields': {
+                'test': 'test'
+            },
+            'start': 1500
+        }
+        mockWork = MagicMock()
+        mockWork.instances = [True] * 600
+        mockRead.return_value = (mockWork, 600, 123456)
+
+        res = enhanceRecord(testRec)
+
+        self.assertEqual(len(mockClassify.mock_calls), 2)
+        mockRead.assert_called_once()
+        mockExtract.assert_called_once()
+        self.assertEqual(len(mockPut.mock_calls), 6)
+        self.assertTrue(res)
 
     @patch('lib.enhancer.classifyRecord', return_value=(True, True), side_effect=OCLCError('testing'))
     def test_enhancer_err(self, mock_classify):

--- a/tests/test_parseOCLC.py
+++ b/tests/test_parseOCLC.py
@@ -22,9 +22,10 @@ class TestOCLCParse(unittest.TestCase):
         work.text = '0000000000'
         mockXML.find = MagicMock(return_value=work)
         mockXML.findall = MagicMock(return_value=[])
-        resWork, resCount = readFromClassify(mockXML, 'testUUID')
+        resWork, resCount, oclcID = readFromClassify(mockXML, 'testUUID')
         self.assertIsInstance(resWork, WorkRecord)
         self.assertEqual(resCount, 1)
+        self.assertEqual(oclcID, '0000000000')
         mockCheck.assert_called_once_with('lookup/owi/1111111')
 
     @patch('lib.parsers.parseOCLC.parseEdition', return_value=True)


### PR DESCRIPTION
The OCLC Classify stage has been encountering errors when dealing with very large responses in terms of number of supposed "editions", generally 3,000+. This is simply too many to handle in the 900s timeout for lambda functions, even with parallel processing for the lookup requests, and because some works can have 10,000+ editions, we simply cannot be sure that this will be handle the scale of any particular job.

To resolve this we can enforce a strict limit on the number of editions parsed per request and hand the remaining editions to another invocation. This can be done with the addition of another parameter "start" and start processing the editions from this point. A relatively small amount of code had to be changed to provide this new capability.